### PR TITLE
replace EntityDescription instead of mutating (see core PR #105211)

### DIFF
--- a/custom_components/bunq/bunq_balance_sensor.py
+++ b/custom_components/bunq/bunq_balance_sensor.py
@@ -1,4 +1,5 @@
 """ bunq sensor"""
+import dataclasses
 from homeassistant.components.sensor import (
     SensorEntity,SensorEntityDescription,SensorDeviceClass
 )
@@ -44,8 +45,11 @@ class BunqBalanceSensor(CoordinatorEntity, SensorEntity):
             LOGGER.debug("no account for id %s", str(self._attr_unique_id))
         else:
             self._attr_native_value = float(account["balance"]["value"])
-            self.entity_description.name = "bunq_" + account["description"].lower().replace(" ", "_")
-            self.entity_description.unit_of_measurement = account["currency"]
+            self.entity_description = dataclasses.replace(
+                self.entity_description,
+                name =  "bunq_" + account["description"].lower().replace(" ", "_"),
+                unit_of_measurement = account["currency"]
+            )
             self.load_transactions(transactions)
             self._attr_extra_state_attributes['account_id'] = self._attr_unique_id
 


### PR DESCRIPTION
Home assistant core will make the EntityDescription object immutable.

Although a grace period was planned until January 2025, EntityDescription is already immutable in 2024.1 (see issue on core: https://github.com/home-assistant/core/issues/107004). This breaks the bunq integration with the following error message:

```
ERROR (MainThread) [homeassistant.components.sensor] Error while setting up bunq platform for sensor
Traceback (most recent call last):
  File "/workspaces/core/homeassistant/helpers/entity_platform.py", line 365, in _async_setup_platform
    await asyncio.shield(task)
  File "/workspaces/core/config/custom_components/bunq/sensor.py", line 18, in async_setup_entry
    sensors.append(BunqBalanceSensor(coordinator, account))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/workspaces/core/config/custom_components/bunq/bunq_balance_sensor.py", line 23, in __init__
    self._async_update_attrs()
  File "/workspaces/core/config/custom_components/bunq/bunq_balance_sensor.py", line 47, in _async_update_attrs
    self.entity_description.name = "bunq_" + account["description"].lower().replace(" ", "_")
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<string>", line 4, in __setattr__
dataclasses.FrozenInstanceError: cannot assign to field 'name'
```

See also:
- https://developers.home-assistant.io/blog/2023/12/11/entity-description-changes/
- https://github.com/home-assistant/core/pull/105211
