### PR TITLE
add count to get more than 10 accounts

### DIFF
--- a/custom_components/bunq/bunq_api.py
+++ b/custom_components/bunq/bunq_api.py
@@ -256,7 +256,7 @@ class BunqApi:
     async def _fetch_monetary_accounts(self):
         return await self._request(
             hdrs.METH_GET,
-            f"/v1/user/{self.status.user_id}/monetary-account",
+            f"/v1/user/{self.status.user_id}/monetary-account?count=25",
             token=self.status.session_token,
         )
 


### PR DESCRIPTION
Turns out the API defaults its pagination limit to 10, while you can have up to 25 accounts.