### PR TITLE
Add allow_dynamic_ip option for users with dynamic IP addresses

### DIFF
--- a/custom_components/bunq/__init__.py
+++ b/custom_components/bunq/__init__.py
@@ -27,6 +27,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     await async_setup_services(hass, coordinator)
 
+    entry.async_on_unload(entry.add_update_listener(async_update_options))
+
     return True
 
 
@@ -35,3 +37,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         del hass.data[DOMAIN][entry.entry_id]
     return unload_ok
+
+
+async def async_update_options(hass: HomeAssistant, entry: ConfigEntry) -> None:
+    """Reload the config entry when options change."""
+    await hass.config_entries.async_reload(entry.entry_id)

--- a/custom_components/bunq/bunq_api.py
+++ b/custom_components/bunq/bunq_api.py
@@ -37,6 +37,7 @@ class BunqApi:
         request_timeout: int = 8,
         session: Optional[ClientSession] = None,
         token_refresh_method: Optional[Callable[[], Awaitable[str]]] = None,
+        allow_dynamic_ip: bool = False,
     ) -> None:
         """Initialize connection with the Bunq API."""
         self.keys = None
@@ -45,6 +46,7 @@ class BunqApi:
         self._session = session
         self.request_timeout = request_timeout
         self.token = token
+        self.allow_dynamic_ip = allow_dynamic_ip
         LOGGER.debug("Session token: %s", token)
         self.token_refresh_method = token_refresh_method
         self._request_id = self._get_request_id(20)
@@ -352,6 +354,9 @@ class BunqApi:
             "description": "Home Assistant",
             "secret": self.token,
         }
+        if self.allow_dynamic_ip:
+            body["permitted_ips"] = ["*"]
+            LOGGER.info("Registering device server with wildcard permitted_ips (dynamic IP mode enabled)")
         device_server = await self._request(
             hdrs.METH_POST, "/v1/device-server", token=installation_token, json=body
         )

--- a/custom_components/bunq/config_flow.py
+++ b/custom_components/bunq/config_flow.py
@@ -5,13 +5,15 @@ import logging
 from collections.abc import Mapping
 from typing import Any
 
+import voluptuous as vol
+from homeassistant.config_entries import ConfigEntry, OptionsFlow
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.config_entry_oauth2_flow import \
     AbstractOAuth2FlowHandler
 
 from .bunq_api import BunqApi
-from .const import DOMAIN, ENVIRONMENT, LOGGER
+from .const import CONF_ALLOW_DYNAMIC_IP, DOMAIN, ENVIRONMENT, LOGGER
 
 
 class BunqFlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
@@ -19,6 +21,11 @@ class BunqFlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
 
     DOMAIN = DOMAIN
     VERSION = 1
+
+    @staticmethod
+    def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
+        """Return the options flow handler."""
+        return BunqOptionsFlowHandler(config_entry)
 
     @property
     def logger(self) -> logging.Logger:
@@ -56,3 +63,32 @@ class BunqFlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
             await self.hass.config_entries.async_reload(existing_entry.entry_id)
             return self.async_abort(reason="reauth_successful")
         return self.async_create_entry(title=status.user_id, data=data)
+
+
+class BunqOptionsFlowHandler(OptionsFlow):
+    """Handle bunq options."""
+
+    def __init__(self, config_entry: ConfigEntry) -> None:
+        """Initialize options flow."""
+        self.config_entry = config_entry
+
+    async def async_step_init(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Manage bunq options."""
+        if user_input is not None:
+            return self.async_create_entry(title="", data=user_input)
+
+        return self.async_show_form(
+            step_id="init",
+            data_schema=vol.Schema(
+                {
+                    vol.Optional(
+                        CONF_ALLOW_DYNAMIC_IP,
+                        default=self.config_entry.options.get(
+                            CONF_ALLOW_DYNAMIC_IP, False
+                        ),
+                    ): bool,
+                }
+            ),
+        )

--- a/custom_components/bunq/const.py
+++ b/custom_components/bunq/const.py
@@ -36,3 +36,5 @@ ATTR_TO_ACCOUNT_ENTITY = "to_account_entity"
 ATTR_ACCOUNT_ENTITY = "account_entity"
 ATTR_CARD_ENTITY = "card_entity"
 ATTR_MESSAGE = "message"
+
+CONF_ALLOW_DYNAMIC_IP: Final = "allow_dynamic_ip"

--- a/custom_components/bunq/coordinator.py
+++ b/custom_components/bunq/coordinator.py
@@ -9,7 +9,7 @@ from homeassistant.helpers.update_coordinator import (DataUpdateCoordinator,
                                                       UpdateFailed)
 
 from .bunq_api import BunqApi
-from .const import DOMAIN, ENVIRONMENT, LOGGER, UPDATE_INTERVAL
+from .const import CONF_ALLOW_DYNAMIC_IP, DOMAIN, ENVIRONMENT, LOGGER, UPDATE_INTERVAL
 from .exceptions import BunqApiError
 from .models import BunqStatus
 
@@ -30,12 +30,15 @@ class BunqDataUpdateCoordinator(DataUpdateCoordinator):
             LOGGER.debug(str(token))
             return str(token)
 
+        allow_dynamic_ip = entry.options.get(CONF_ALLOW_DYNAMIC_IP, False)
+
         client_session = async_get_clientsession(hass)
         self.bunq = BunqApi(
             environment=ENVIRONMENT,
             token=session.token["access_token"],
             session=client_session,
             token_refresh_method=async_token_refresh,
+            allow_dynamic_ip=allow_dynamic_ip,
         )
 
         super().__init__(hass, LOGGER, name=DOMAIN, update_interval=UPDATE_INTERVAL)

--- a/custom_components/bunq/strings.json
+++ b/custom_components/bunq/strings.json
@@ -1,0 +1,15 @@
+{
+  "options": {
+    "step": {
+      "init": {
+        "title": "bunq options",
+        "data": {
+          "allow_dynamic_ip": "Allow dynamic IP address"
+        },
+        "data_description": {
+          "allow_dynamic_ip": "Register the device server with a wildcard IP (`*`) instead of your current IP. Enable this if your ISP assigns a new IP address frequently. Note: this reduces account security."
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Adds an options flow toggle that, when enabled, registers the bunq
device server with a wildcard permitted_ips value ("*") instead of
the current IP address. This allows users whose ISP assigns a new
IP on every reconnect to keep the integration working without
manual re-authentication.

Closes #27

https://claude.ai/code/session_01AUcBB3oRm8xHdFRmB5s6MU