### PR TITLE
Fix options flow 500 error on settings open

### DIFF
--- a/custom_components/bunq/config_flow.py
+++ b/custom_components/bunq/config_flow.py
@@ -25,7 +25,7 @@ class BunqFlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
     @staticmethod
     def async_get_options_flow(config_entry: ConfigEntry) -> OptionsFlow:
         """Return the options flow handler."""
-        return BunqOptionsFlowHandler(config_entry)
+        return BunqOptionsFlowHandler()
 
     @property
     def logger(self) -> logging.Logger:
@@ -67,10 +67,6 @@ class BunqFlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
 
 class BunqOptionsFlowHandler(OptionsFlow):
     """Handle bunq options."""
-
-    def __init__(self, config_entry: ConfigEntry) -> None:
-        """Initialize options flow."""
-        self.config_entry = config_entry
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None


### PR DESCRIPTION
## Summary

- Fixes a 500 Internal Server Error when opening the integration settings (Configure button)

## Root Cause

In modern Home Assistant, `OptionsFlow` exposes `config_entry` as a **read-only property** that the framework injects automatically after instantiation. The previous implementation overrode `__init__` and tried to set `self.config_entry = config_entry`, which raised `AttributeError: can't set attribute` — reported by HA as a 500.

## Fix

- Removed the custom `__init__` from `BunqOptionsFlowHandler`
- Changed `async_get_options_flow` to return `BunqOptionsFlowHandler()` with no arguments

`self.config_entry` in `async_step_init` continues to work as before — HA sets it automatically before invoking the step.

## Test plan

- [ ] Go to **Settings → Devices & Services → bunq → Configure**
- [ ] Options form loads without error, showing the "Allow dynamic IP address" toggle
- [ ] Toggle on → Save → integration reloads
- [ ] Toggle off → Save → integration reloads

https://claude.ai/code/session_01AUcBB3oRm8xHdFRmB5s6MU