### PR TITLE
Add allow dynamic IP option (issue #27) + fix options flow 500 error

### DIFF
--- a/custom_components/bunq/config_flow.py
+++ b/custom_components/bunq/config_flow.py
@@ -34,34 +34,64 @@ class BunqFlowHandler(AbstractOAuth2FlowHandler, domain=DOMAIN):
 
     async def async_step_reauth(self, entry_data: Mapping[str, Any]) -> FlowResult:
         """Perform reauth upon an API authentication error."""
+        LOGGER.debug("async_step_reauth: reauth required, moving to confirm step")
         return await self.async_step_reauth_confirm()
 
     async def async_step_reauth_confirm(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
         """Dialog that informs the user that reauth is required."""
+        LOGGER.debug("async_step_reauth_confirm: user_input=%s", user_input is not None)
         if user_input is None:
             return self.async_show_form(step_id="reauth_confirm")
+        LOGGER.debug("async_step_reauth_confirm: confirmed, starting user step")
         return await self.async_step_user()
 
     async def async_oauth_create_entry(self, data: dict[str, Any]) -> FlowResult:
         """Create an oauth config entry or update existing entry for reauth."""
-        api = BunqApi(
-            environment=ENVIRONMENT,
-            token=data["token"]["access_token"],
-            session=async_get_clientsession(self.hass),
-        )
+        LOGGER.debug("async_oauth_create_entry: received token data keys=%s", list(data.get("token", {}).keys()))
 
-        status = await api.update()
-        if not status.user_id or not status.session_token:
+        token = data.get("token", {})
+        if not token.get("access_token"):
+            LOGGER.error("async_oauth_create_entry: access_token missing from token data")
             return self.async_abort(reason="oauth_error")
 
-        if existing_entry := await self.async_set_unique_id(
-            status.user_id.lower()
-        ):
+        LOGGER.debug("async_oauth_create_entry: creating BunqApi and calling update()")
+        try:
+            api = BunqApi(
+                environment=ENVIRONMENT,
+                token=token["access_token"],
+                session=async_get_clientsession(self.hass),
+            )
+            status = await api.update()
+        except Exception as err:
+            LOGGER.error("async_oauth_create_entry: BunqApi.update() failed: %s", err, exc_info=True)
+            return self.async_abort(reason="oauth_error")
+
+        LOGGER.debug(
+            "async_oauth_create_entry: update() result: user_id=%s, session_token_present=%s",
+            status.user_id,
+            bool(status.session_token),
+        )
+
+        if not status.user_id or not status.session_token:
+            LOGGER.error(
+                "async_oauth_create_entry: aborting — user_id=%s, session_token_present=%s",
+                status.user_id,
+                bool(status.session_token),
+            )
+            return self.async_abort(reason="oauth_error")
+
+        unique_id = status.user_id.lower()
+        LOGGER.debug("async_oauth_create_entry: setting unique_id=%s", unique_id)
+
+        if existing_entry := await self.async_set_unique_id(unique_id):
+            LOGGER.debug("async_oauth_create_entry: existing entry found, updating and reloading")
             self.hass.config_entries.async_update_entry(existing_entry, data=data)
             await self.hass.config_entries.async_reload(existing_entry.entry_id)
             return self.async_abort(reason="reauth_successful")
+
+        LOGGER.debug("async_oauth_create_entry: creating new config entry for user_id=%s", status.user_id)
         return self.async_create_entry(title=status.user_id, data=data)
 
 

--- a/custom_components/bunq/oauth.py
+++ b/custom_components/bunq/oauth.py
@@ -8,7 +8,7 @@ from homeassistant.components.application_credentials import (
     AuthImplementation, AuthorizationServer, ClientCredential)
 from homeassistant.core import HomeAssistant
 
-from .const import ENVIRONMENT, ENVIRONMENT_URLS
+from .const import ENVIRONMENT, ENVIRONMENT_URLS, LOGGER
 
 
 class BunqOAuth2Implementation(AuthImplementation):
@@ -21,6 +21,12 @@ class BunqOAuth2Implementation(AuthImplementation):
         credential: ClientCredential,
     ) -> None:
         """Local Bunq Oauth Implementation."""
+        LOGGER.debug(
+            "BunqOAuth2Implementation.__init__: environment=%s, authorize_url=%s, token_url=%s",
+            ENVIRONMENT,
+            ENVIRONMENT_URLS[ENVIRONMENT]["authorize_url"],
+            ENVIRONMENT_URLS[ENVIRONMENT]["token_url"],
+        )
         super().__init__(
             hass=hass,
             auth_domain=auth_domain,
@@ -38,14 +44,62 @@ class BunqOAuth2Implementation(AuthImplementation):
 
     async def async_resolve_external_data(self, external_data: Any) -> dict:
         """Initialize local Bunq API auth implementation."""
+        LOGGER.debug(
+            "async_resolve_external_data: received external_data keys=%s, state keys=%s",
+            list(external_data.keys()) if isinstance(external_data, dict) else type(external_data),
+            list(external_data.get("state", {}).keys()) if isinstance(external_data, dict) else "n/a",
+        )
+
+        if "state" not in external_data:
+            LOGGER.error("async_resolve_external_data: 'state' key missing from external_data. Full keys: %s", list(external_data.keys()))
+            raise KeyError("'state' missing from external_data")
+
+        if "redirect_uri" not in external_data["state"]:
+            LOGGER.error(
+                "async_resolve_external_data: 'redirect_uri' missing from state. State keys: %s",
+                list(external_data["state"].keys()),
+            )
+            raise KeyError("'redirect_uri' missing from state")
+
+        if "code" not in external_data:
+            LOGGER.error("async_resolve_external_data: 'code' missing from external_data. Keys: %s", list(external_data.keys()))
+            raise KeyError("'code' missing from external_data")
+
         redirect_uri = external_data["state"]["redirect_uri"]
-        self.token_url = f"{ENVIRONMENT_URLS[ENVIRONMENT]['token_url']}?grant_type=authorization_code&client_id={self.client_id}&client_secret={self.client_secret}&code={external_data['code']}&redirect_uri={redirect_uri}"
-        token = await self._token_request({})
+        LOGGER.debug("async_resolve_external_data: redirect_uri=%s", redirect_uri)
+
+        token_base_url = ENVIRONMENT_URLS[ENVIRONMENT]["token_url"]
+        self.token_url = (
+            f"{token_base_url}"
+            f"?grant_type=authorization_code"
+            f"&client_id={self.client_id}"
+            f"&client_secret={self.client_secret}"
+            f"&code={external_data['code']}"
+            f"&redirect_uri={redirect_uri}"
+        )
+        LOGGER.debug(
+            "async_resolve_external_data: requesting token from %s (secret and code redacted)",
+            token_base_url,
+        )
+
+        try:
+            token = await self._token_request({})
+        except Exception as err:
+            LOGGER.error("async_resolve_external_data: token request failed: %s", err, exc_info=True)
+            raise
+
+        LOGGER.debug(
+            "async_resolve_external_data: token received, keys=%s",
+            list(token.keys()) if isinstance(token, dict) else type(token),
+        )
+
         # Store the redirect_uri (Needed for refreshing token, but not according to oAuth2 spec!)
         token["redirect_uri"] = redirect_uri
         token["expires_in"] = sys.maxsize
+        LOGGER.debug("async_resolve_external_data: token resolved successfully")
         return token
 
     async def _async_refresh_token(self, token: dict) -> dict:
-        """ Bunq does not provide a way to refresh the token."""
+        """Bunq does not provide a way to refresh the token."""
+        LOGGER.debug("_async_refresh_token: bunq does not support token refresh, returning existing token")
         return {**token, **token}


### PR DESCRIPTION
Closes #27

## Summary

- Adds an **Allow dynamic IP address** toggle in the integration options flow (Settings → Devices & Services → bunq → Configure) that registers the bunq device server with a wildcard `permitted_ips: ["*"]` instead of the current IP — required for users whose ISP reassigns their IP on every reconnect
- Fixes a **500 Internal Server Error** when opening the Configure dialog, caused by `OptionsFlow.config_entry` being a read-only property in modern Home Assistant — our previous `__init__` tried to set it and crashed
- Adds **exhaustive debug logging** throughout the OAuth flow so failures are self-diagnosable from HA logs without back-and-forth

## Changes

| File | What changed |
|------|-------------|
| `const.py` | Added `CONF_ALLOW_DYNAMIC_IP` constant |
| `bunq_api.py` | `allow_dynamic_ip` param — adds `permitted_ips: ["*"]` to device-server POST when enabled |
| `coordinator.py` | Reads option from `entry.options`, passes to `BunqApi` |
| `config_flow.py` | `BunqOptionsFlowHandler` (no custom `__init__`), verbose logging in `async_oauth_create_entry` |
| `__init__.py` | Reload listener on option change |
| `strings.json` | *(new)* UI labels and description for the options toggle |
| `oauth.py` | Explicit error checks + debug logging in `async_resolve_external_data` |

## Test plan

- [ ] Go to **Settings → Devices & Services → bunq → Configure** — options form loads without 500 error
- [ ] Toggle **Allow dynamic IP address** on → Save → integration reloads; HA log shows `Registering device server with wildcard permitted_ips`
- [ ] Toggle off → Save → integration reloads; log line absent
- [ ] Add integration from scratch — OAuth flow completes; HA debug log shows each step in `async_resolve_external_data` and `async_oauth_create_entry`

https://claude.ai/code/session_01AUcBB3oRm8xHdFRmB5s6MU